### PR TITLE
Add bugfix #4 - Wrong calculation of profit

### DIFF
--- a/functions/Mynt.Core/TradeManagers/BittrexTradeManager.cs
+++ b/functions/Mynt.Core/TradeManagers/BittrexTradeManager.cs
@@ -380,7 +380,7 @@ namespace Mynt.Core.TradeManagers
         private async Task<double> ExecuteSellOrder(Trade trade, double currentRateBid, double balance)
         {
             // Calculate our profit.
-            var investment = (Constants.AmountOfBtcToInvestPerTrader * (1 - Constants.TransactionFeePercentage));
+            var investment = (trade.StakeAmount * (1 - Constants.TransactionFeePercentage));
             var sales = (trade.Quantity * currentRateBid) - (trade.Quantity * currentRateBid * Constants.TransactionFeePercentage);
             var profit = 100 * ((sales - investment) / investment);
 


### PR DESCRIPTION
Wrong calculation of profit in **ExecuteSellOrder** method if the **AmountOfBtcToInvestPerTrader** is changed after the buy fixed by using` trade.StakeAmount` instead of `Constants.AmountOfBtcToInvestPerTrader`