### PR TITLE
Fixed bug that removed all markets when filtering for OnlyTrade

### DIFF
--- a/src/Mynt.Core/TradeManagers/LiveTradeManager.cs
+++ b/src/Mynt.Core/TradeManagers/LiveTradeManager.cs
@@ -292,8 +292,9 @@ namespace Mynt.Core.TradeManagers
                  _settings.QuoteCurrency.ToUpper() == x.CurrencyPair.QuoteCurrency.ToUpper()).ToList();
 
             // If there are items on the only trade list remove the rest
-            foreach (var item in _settings.OnlyTradeList)
-                markets.RemoveAll(x => x.CurrencyPair.BaseCurrency != item);
+            markets = markets.Where(m => _settings.OnlyTradeList
+                                            .Any(c => c == m.CurrencyPair.BaseCurrency))
+                             .ToList();
 
             // Remove existing trades from the list to check.
             foreach (var trade in _activeTrades)


### PR DESCRIPTION
If in the OnlyTrade list you have more than one coin, then the markets list will be empty after the filter is made.

For example:
OnlyTrade = ["ETC", "ETH"]
markets = ["XRP", "ETC", "ETH"]

**Expected behavior:** 
- after the filter, markets should only have ETC and ETH

**Actual behavior:** 
- markets will be empty because RemoveAll will remove all coins that are not ETC, thus removing XRP and ETH from the list, then it will remove all coins that are not ETH, so it will remove ETC which will leave the list empty.